### PR TITLE
docs(readme): removed unnecessary spacing in in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ In this system, you perform minimal changes to the `module.json` as it is popula
 Clone the repository
 
 ```
-     HTTPS: git clone https://github.com/flamewave000/fvtt-module-template.git
-       SSH: git clone git@github.com:flamewave000/fvtt-module-template.git
+HTTPS: git clone https://github.com/flamewave000/fvtt-module-template.git
+SSH: git clone git@github.com:flamewave000/fvtt-module-template.git
 GitHub CLI: gh repo clone flamewave000/fvtt-module-template
 ```
 


### PR DESCRIPTION
Removed unnecessary spacing for the links under How To Use >> Clone the repository